### PR TITLE
Some fixes based on user feedback and real-world usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `list-fixtures` command ([#10])
 - `load-fixture` command ([#10])
 - `DB.execute_sql()` method for running arbitrary SQL against a database ([#10])
+- `execute-sql` command ([#10])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.2.0] - 2023-06-22
+
+### Added
+
+- `list-fixtures` command ([#10])
+- `load-fixture` command ([#10])
+- `DB.execute_sql()` method for running arbitrary SQL against a database ([#10])
+
+### Changed
+
+- Schema version when applying `schema.sql` comes from max migration version,
+  removing the need to track the version table and update it in that file. ([#10])
+
 ## [v0.1.0] - 2023-05-25
 
 Initial release
 
-[unreleased]: https://github.com/element84/dbami/compare/v0.1.0...main
+[unreleased]: https://github.com/element84/dbami/compare/v0.2.0...main
+[v0.2.0]: https://github.com/element84/dbami/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/element84/dbami/tree/v0.1.0
+
+[#10]: https://github.com/Element84/dbami/pull/10

--- a/src/dbami/cli.py
+++ b/src/dbami/cli.py
@@ -415,7 +415,7 @@ class Rollback(DbamiCommand):
                     direction="down",
                     database=args.database,
                 )
-            except exceptions.DirectionError as e:
+            except (exceptions.DirectionError, exceptions.MigrationError) as e:
                 printe(e)
                 return 1
             return 0
@@ -444,7 +444,7 @@ class Up(DbamiCommand):
 
             try:
                 await args.db.migrate(direction="up", database=args.database)
-            except exceptions.DirectionError as e:
+            except (exceptions.DirectionError, exceptions.MigrationError) as e:
                 printe(e)
                 return 1
             return 0

--- a/src/dbami/cli.py
+++ b/src/dbami/cli.py
@@ -538,6 +538,26 @@ class LoadFixture(DbamiCommand):
         return syncrun(run())
 
 
+class ExecuteSql(DbamiCommand):
+    help: str = "Run SQL from stdin against the database"
+    name: str = "execute-sql"
+
+    def set_args(
+        self,
+        parser: argparse.ArgumentParser,
+    ) -> None:
+        Arguments.project(parser)
+        Arguments.wait_timeout(parser)
+        Arguments.database(parser)
+
+    def __call__(self, args: argparse.Namespace) -> int:
+        async def run() -> int:
+            await args.db.execute_sql(sys.stdin.read(), database=args.database)
+            return 0
+
+        return syncrun(run())
+
+
 class CLI(abc.ABC):
     def __init__(
         self,
@@ -604,6 +624,7 @@ class DbamiCLI(CLI):
             Version(),
             ListFixtures(),
             LoadFixture(),
+            ExecuteSql(),
         )
     }
 

--- a/src/dbami/db.py
+++ b/src/dbami/db.py
@@ -168,9 +168,7 @@ class DB:
                 "Project is missing base migration file. Try reinitializing."
             )
 
-        self.fixtures = {
-            f.name: f for f in (SqlFile(f) for f in self.fixtures_dir.glob("*.sql"))
-        }
+        self.fixtures = self.load_fixtures_from_dir(self.fixtures_dir)
         self.schema_version_table = schema_version_table
 
     @classmethod
@@ -205,6 +203,13 @@ class DB:
     @property
     def fixtures_dir(self):
         return self.project_fixtures(self.project_dir)
+
+    @staticmethod
+    def load_fixtures_from_dir(directory: Path) -> dict[str, SqlFile]:
+        return {f.name: f for f in (SqlFile(f) for f in directory.glob("*.sql"))}
+
+    def add_fixture_dir(self, directory: Path) -> None:
+        self.fixtures.update(self.load_fixtures_from_dir(directory))
 
     def validate_project(self):
         schema = self.schema_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,17 @@ def project(tmp_chdir: Path):
 
 
 @pytest.fixture
+def extra_fixtures(tmp_path: Path) -> Path:
+    tfdir = tmp_path.joinpath("test_fixtures")
+    tfdir.mkdir()
+    # override the fixture in the project fixtures dir
+    tfdir.joinpath("a_fixture.sql").touch()
+    # add another fixture
+    tfdir.joinpath("b_fixture.sql").touch()
+    return tfdir
+
+
+@pytest.fixture
 def tmp_db(test_db_name_stem):
     db_name = random_name(test_db_name_stem)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,23 +33,9 @@ def project(tmp_chdir: Path):
     # to ensure we test the migration load process
     migrations_dir = DB.project_migrations(tmp_chdir)
     migrations_dir.mkdir()
-    migrations_dir.joinpath("00_migration.up.sql").touch()
-    migrations_dir.joinpath("00_migration.down.sql").touch()
+    migrations_dir.joinpath("00000_base.down.sql").touch()
     migrations_dir.joinpath("01_migration.up.sql").touch()
     db: DB = DB.new_project(tmp_chdir)
-    db.schema.path.write_text(
-        """
-CREATE TABLE IF NOT EXISTS schema_version (
-  version integer,
-  applied_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE INDEX ON schema_version (version);
-CREATE INDEX ON schema_version (applied_at);
-
-INSERT INTO schema_version (version) VALUES (4);
-"""
-    )
     db.new_migration("migration")
     db.new_migration("migration")
     db.new_migration("migration")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -476,3 +476,20 @@ def test_load_fixtures_extra(tmp_db, project_dir, extra_fixtures):
     print(out)
     print(err)
     assert rc == 0
+
+
+def test_execute_sql(tmp_db, project):
+    stdin = io.StringIO()
+    stdin.write("create table a_table (id int primary key);")
+    stdin.seek(0)
+    rc, out, err = run_cli(
+        "execute-sql",
+        "--database",
+        tmp_db,
+        stdin=stdin,
+    )
+    print(out)
+    print(err)
+    assert rc == 0
+    syncrun(project.execute_sql("select * from a_table", database=tmp_db))
+    assert True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import asyncpg
 import pytest
 
 from dbami import exceptions
-from dbami.cli import get_cli
+from dbami.__main__ import main as cli_main
 from dbami.db import DB
 from dbami.util import random_name, syncrun
 
@@ -29,7 +29,7 @@ def run_cli(*args, stdin: Optional[TextIO] = None):
     rc = None
     with replace_streams(stdin=stdin) as (out, err):
         try:
-            get_cli()(args)
+            cli_main(args)
         except SystemExit as e:
             rc = e.code
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ import pytest
 from dbami import exceptions
 from dbami.__main__ import main as cli_main
 from dbami.db import DB
-from dbami.util import random_name, syncrun
+from dbami.util import syncrun
 
 
 @contextlib.contextmanager
@@ -50,19 +50,6 @@ async def database_exists(dbname) -> bool:
 @pytest.fixture
 def project_dir(project: DB) -> Path:
     return project.project_dir
-
-
-@pytest.fixture
-def tmp_db_name():
-    db_name = random_name("dbami_test")
-
-    try:
-        yield db_name
-    finally:
-        try:
-            syncrun(DB.drop_database(db_name))
-        except asyncpg.InvalidCatalogNameError:
-            pass
 
 
 def test_cli():
@@ -470,18 +457,18 @@ def test_list_fixtures_extra(project_dir, extra_fixtures):
     assert len(out.splitlines()) == 2
 
 
-def test_load_fixture(tmp_db_name, project_dir):
-    rc, out, err = run_cli("load-fixture", "--database", tmp_db_name, "a_fixture")
+def test_load_fixture(tmp_db, project_dir):
+    rc, out, err = run_cli("load-fixture", "--database", tmp_db, "a_fixture")
     print(out)
     print(err)
     assert rc == 0
 
 
-def test_load_fixtures_extra(tmp_db_name, project_dir, extra_fixtures):
+def test_load_fixtures_extra(tmp_db, project_dir, extra_fixtures):
     rc, out, err = run_cli(
         "load-fixture",
         "--database",
-        tmp_db_name,
+        tmp_db,
         "--fixture-dir",
         str(extra_fixtures),
         "b_fixture",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -451,3 +451,41 @@ def test_version():
     print(err)
     assert rc == 0
     assert out.strip().endswith(str(__version__))
+
+
+def test_list_fixtures(project_dir):
+    rc, out, err = run_cli("list-fixtures")
+    print(out)
+    print(err)
+    assert rc == 0
+    assert len(out.splitlines()) == 1
+    assert out.startswith("a_fixture (")
+
+
+def test_list_fixtures_extra(project_dir, extra_fixtures):
+    rc, out, err = run_cli("list-fixtures", "--fixture-dir", str(extra_fixtures))
+    print(out)
+    print(err)
+    assert rc == 0
+    assert len(out.splitlines()) == 2
+
+
+def test_load_fixture(tmp_db_name, project_dir):
+    rc, out, err = run_cli("load-fixture", "--database", tmp_db_name, "a_fixture")
+    print(out)
+    print(err)
+    assert rc == 0
+
+
+def test_load_fixtures_extra(tmp_db_name, project_dir, extra_fixtures):
+    rc, out, err = run_cli(
+        "load-fixture",
+        "--database",
+        tmp_db_name,
+        "--fixture-dir",
+        str(extra_fixtures),
+        "b_fixture",
+    )
+    print(out)
+    print(err)
+    assert rc == 0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -277,3 +277,11 @@ def test_load_project_dir(project) -> None:
         child = child.child
 
     assert len(migrations) == expected_migration_count
+
+
+def test_add_fixture_dir(project, extra_fixtures) -> None:
+    project.add_fixture_dir(extra_fixtures)
+
+    assert len(project.fixtures) == 2
+    for fixture in project.fixtures.values():
+        assert fixture.path.parent == extra_fixtures


### PR DESCRIPTION
* Get schema version from max migration version, rather than having to declare and update table in `schema.sql`
* New commands to list fixtures and to load a fixture
* Factor out a new `execute_sql` method on the `DB` class to allow execution of arbitrary sql without having to make a `SqlFile` instance
* Use `__main__.main()` as the entry point for CLI testing to ensure that file is tested